### PR TITLE
Typescript install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,8 @@ setup_server: setup_base
 setup_web: setup_base
 	sudo apt-get install -y nodejs
 	sudo rm -f /usr/bin/node && sudo ln -s /usr/bin/nodejs /usr/bin/node
-	npm install typescript
+	sudo apt-get install -y npm
+	sudo npm install -g typescript
 	npm install @types/jquery@2.0.46 @types/jquery-mousewheel@3.1.5 websocket @types/node
 
 .PHONY: setup_os

--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,8 @@ setup_base:
 	sudo apt-get install -y g++-arm-linux-gnueabihf
 	sudo apt-get install -y python-pip
 	sudo apt-get install -y curl
-	pip install -r $(SDK_PATH)/requirements.txt
-	pip install $(SDK_PATH)/python
+	sudo pip2 install -r $(SDK_PATH)/requirements.txt
+	sudo pip2 install $(SDK_PATH)/python
 
 .PHONY: setup_fpga
 setup_fpga: setup_base


### PR DESCRIPTION
Install typescript globally to access `tsc` for `/usr/bin`. Alternative is using the path `node_modules/typescript/bin/tsc` instead of ``tsc` in web.mk.