### PR TITLE
Add GCC_VERSION variable to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ KOHERON_VERSION := $(shell cat $(KOHERON_VERSION_FILE))
 VIVADO_VERSION := 2017.2
 VIVADO_PATH := /opt/Xilinx/Vivado
 PYTHON := python3
+# Change GCC_VERSION to 7 if running Ubuntu 20.04
+GCC_VERSION := 5
 
 .PHONY: help
 help:
@@ -142,7 +144,7 @@ setup: setup_fpga setup_server setup_web setup_os
 
 .PHONY: setup_base
 setup_base:
-	sudo apt-get install -y g++-5-arm-linux-gnueabihf
+	sudo apt-get install -y g++-$(GCC_VERSION)-arm-linux-gnueabihf
 	# On Ubuntu 18.04 you may have to link:	
 	# sudo ln -s /usr/bin/arm-linux-gnueabihf-gcc-5 /usr/bin/arm-linux-gnueabihf-gcc
 	# sudo ln -s /usr/bin/arm-linux-gnueabihf-g++-5 /usr/bin/arm-linux-gnueabihf-g++	

--- a/server/server.mk
+++ b/server/server.mk
@@ -49,7 +49,7 @@ OBJ := $(SERVER_OBJ) $(INTERFACE_DRIVERS_OBJ) $(DRIVERS_OBJ) $(CONTEXT_OBJS)
 DEP := $(subst .o,.d,$(OBJ))
 -include $(DEP)
 
-SERVER_CCXX := /usr/bin/arm-linux-gnueabihf-g++-5 -flto
+SERVER_CCXX := /usr/bin/arm-linux-gnueabihf-g++-$(GCC_VERSION) -flto
 
 SERVER_CCXXFLAGS := -Wall -Werror -Wextra
 SERVER_CCXXFLAGS += -Wpedantic -Wfloat-equal -Wunused-macros -Wcast-qual -Wuseless-cast


### PR DESCRIPTION
GCC version 5 is no longer available on Ubuntu 20.04.
Add possibility to set GCC_VERSION to 7.