### PR TITLE
Update linux cflags

### DIFF
--- a/os/os.mk
+++ b/os/os.mk
@@ -28,8 +28,8 @@ UBOOT_TAR := $(TMP)/u-boot-xlnx-$(UBOOT_TAG).tar.gz
 LINUX_TAR := $(TMP)/linux-xlnx-$(LINUX_TAG).tar.gz
 DTREE_TAR := $(TMP)/device-tree-xlnx-$(DTREE_TAG).tar.gz
 
-LINUX_CFLAGS := "-O2 -march=armv7-a -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=hard"
-UBOOT_CFLAGS := "-O2 -march=armv7-a -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=hard"
+LINUX_CFLAGS := "-O2 -mcpu=cortex-a9 -mfpu=vfpv3-d16 -mvectorize-with-neon-quad -mfloat-abi=hard"
+UBOOT_CFLAGS := "-O2 -mcpu=cortex-a9 -mfpu=vfpv3-d16 -mvectorize-with-neon-quad -mfloat-abi=hard"
 
 TMP_OS_VERSION_FILE := $(TMP_OS_PATH)/version.json
 


### PR DESCRIPTION
Update CFLAGS used for U-BOOT and LINUX.

Use same flags as for the server.

Should fix #542.