### PR TITLE
add option to compile via docker (see PR #594)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SHELL := bash
 CONFIG ?= examples/red-pitaya/led-blinker/config.yml
 SDK_PATH ?= .
 MODE ?= development
+SDK_FULL_PATH = $(realpath $(SDK_PATH))
 HOST ?= 192.168.1.100
 TMP ?= tmp
 
@@ -25,6 +26,9 @@ set_gcc_version:
 	unlink /usr/bin/arm-linux-gnueabihf-gcc
 	ln -s /usr/bin/arm-linux-gnueabihf-gcc-$(GCC_VERSION) /usr/bin/arm-linux-gnueabihf-gcc
 	arm-linux-gnueabihf-gcc --version
+
+BUILD_METHOD := native
+#BUILD_METHOD = docker
 
 .PHONY: help
 help:
@@ -51,6 +55,13 @@ MEMORY_YML := $(TMP_PROJECT_PATH)/memory.yml
 N_CPUS ?= $(shell nproc 2> /dev/null || echo 1)
 
 NAME := $(shell $(MAKE_PY) --name $(CONFIG) $(TMP_PROJECT_PATH)/name && cat $(TMP_PROJECT_PATH)/name)
+
+###############################################################################
+# DOCKER
+###############################################################################
+DOCKER_PATH := $(SDK_PATH)/docker
+DOCKER_MK ?= $(DOCKER_PATH)/docker.mk
+include $(DOCKER_MK)
 
 ###############################################################################
 # INSTRUMENT
@@ -147,7 +158,7 @@ include $(PYTHON_MK)
 ###############################################################################
 
 .PHONY: setup
-setup: setup_fpga setup_server setup_web setup_os
+setup: setup_docker setup_fpga setup_server setup_web setup_os
 
 .PHONY: setup_base
 setup_base:
@@ -159,6 +170,12 @@ setup_base:
 	sudo apt-get install -y curl
 	$(PIP) install -r $(SDK_PATH)/requirements.txt
 	$(PIP) install $(SDK_PATH)/python
+
+.PHONY: setup_docker
+setup_docker: setup_base
+	sudo bash docker/install_docker.sh
+	sudo usermod -aG docker $(shell whoami)
+	sudo docker build -t gnu-gcc-9.5 ./docker/.
 
 .PHONY: setup_fpga
 setup_fpga: setup_base

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM gcc:9.5
+RUN apt update
+RUN apt install -y binutils-aarch64-linux-gnu binutils-arm-linux-gnueabi gcc-9-arm-linux-gnueabihf g++-9-arm-linux-gnueabihf gcc-9-aarch64-linux-gnu  g++-9-aarch64-linux-gnu
+RUN apt install -y g++-arm-linux-gnueabihf
+RUN apt install -y gcc-arm-none-eabi
+RUN apt install -y flex bison bc u-boot-tools
+ENV TERM=xterm-256color
+USER containeruser
+

--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -1,0 +1,6 @@
+DOCKER :=
+ifeq ($(BUILD_METHOD),docker)
+	UID = $(shell id -u)
+	GID = $(shell id -g)
+	DOCKER = docker run --rm -v $(SDK_FULL_PATH):/home/containeruser/wkspace:Z -u $(UID):$(GID) -w /home/containeruser/wkspace gnu-gcc-9.5
+endif

--- a/docker/install_docker.sh
+++ b/docker/install_docker.sh
@@ -1,0 +1,16 @@
+# Add Docker's official GPG key:
+apt-get update
+apt-get install ca-certificates curl
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update
+
+# Install Docker
+apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin

--- a/os/os.mk
+++ b/os/os.mk
@@ -28,6 +28,7 @@ UBOOT_TAR := $(TMP)/u-boot-xlnx-$(UBOOT_TAG).tar.gz
 LINUX_TAR := $(TMP)/linux-xlnx-$(LINUX_TAG).tar.gz
 DTREE_TAR := $(TMP)/device-tree-xlnx-$(DTREE_TAG).tar.gz
 
+FSBL_CFLAGS := "-O2 -march=armv7-a -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=hard"
 LINUX_CFLAGS := "-O2 -march=armv7-a -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=hard"
 UBOOT_CFLAGS := "-O2 -march=armv7-a -mcpu=cortex-a9 -mfpu=neon -mfloat-abi=hard"
 
@@ -68,7 +69,7 @@ $(TMP_OS_PATH)/fsbl/Makefile: $(TMP_FPGA_PATH)/$(NAME).hwdef
 
 $(TMP_OS_PATH)/fsbl/executable.elf: $(TMP_OS_PATH)/fsbl/Makefile $(FSBL_FILES)
 	cp -a $(FSBL_PATH)/. $(TMP_OS_PATH)/fsbl/ 2>/dev/null || true
-	source $(VIVADO_PATH)/$(VIVADO_VERSION)/settings64.sh && $(DOCKER) make -C $(@D) all
+	source $(VIVADO_PATH)/$(VIVADO_VERSION)/settings64.sh && $(DOCKER) make -C $(@D) CFLAGS=$(FSBL_CFLAGS) all
 	@echo [$@] OK
 
 .PHONY: clean_fsbl

--- a/os/os.mk
+++ b/os/os.mk
@@ -68,7 +68,7 @@ $(TMP_OS_PATH)/fsbl/Makefile: $(TMP_FPGA_PATH)/$(NAME).hwdef
 
 $(TMP_OS_PATH)/fsbl/executable.elf: $(TMP_OS_PATH)/fsbl/Makefile $(FSBL_FILES)
 	cp -a $(FSBL_PATH)/. $(TMP_OS_PATH)/fsbl/ 2>/dev/null || true
-	source $(VIVADO_PATH)/$(VIVADO_VERSION)/settings64.sh && make -C $(@D) all
+	source $(VIVADO_PATH)/$(VIVADO_VERSION)/settings64.sh && $(DOCKER) make -C $(@D) all
 	@echo [$@] OK
 
 .PHONY: clean_fsbl
@@ -91,9 +91,9 @@ $(UBOOT_PATH): $(UBOOT_TAR)
 
 $(TMP_OS_PATH)/u-boot.elf: $(UBOOT_PATH)
 	mkdir -p $(@D)
-	make -C $< mrproper
-	make -C $< arch=arm `find $(PATCHES) -name '*_defconfig' -exec basename {} \;`
-	make -C $< arch=arm CFLAGS=$(UBOOT_CFLAGS) \
+	$(DOCKER) make -C $< mrproper
+	$(DOCKER) make -C $< arch=arm `find $(PATCHES) -name '*_defconfig' -exec basename {} \;`
+	$(DOCKER) make -C $< arch=arm CFLAGS=$(UBOOT_CFLAGS) \
 	  CROSS_COMPILE=arm-linux-gnueabihf- all
 	cp $</u-boot $@
 	@echo [$@] OK
@@ -155,9 +155,9 @@ $(LINUX_PATH): $(LINUX_TAR)
 	@echo [$@] OK
 
 $(TMP_OS_PATH)/uImage: $(LINUX_PATH)
-	make -C $< mrproper
-	make -C $< ARCH=arm xilinx_zynq_defconfig
-	make -C $< ARCH=arm CFLAGS=$(LINUX_CFLAGS) \
+	$(DOCKER) make -C $< mrproper
+	$(DOCKER) make -C $< ARCH=arm xilinx_zynq_defconfig
+	$(DOCKER) make -C $< ARCH=arm CFLAGS=$(LINUX_CFLAGS) \
 	  --jobs=$(N_CPUS) \
 	  CROSS_COMPILE=arm-linux-gnueabihf- UIMAGE_LOADADDR=0x8000 uImage
 	cp $</arch/arm/boot/uImage $@

--- a/server/server.mk
+++ b/server/server.mk
@@ -50,6 +50,9 @@ DEP := $(subst .o,.d,$(OBJ))
 -include $(DEP)
 
 SERVER_CCXX := /usr/bin/arm-linux-gnueabihf-g++-$(GCC_VERSION) -flto
+ifeq ($(BUILD_METHOD),docker)
+	SERVER_CCXX = $(DOCKER) arm-linux-gnueabihf-g++-$(GCC_VERSION) -flto
+endif
 
 SERVER_CCXXFLAGS := -Wall -Werror -Wextra
 SERVER_CCXXFLAGS += -Wpedantic -Wfloat-equal -Wunused-macros -Wcast-qual -Wuseless-cast


### PR DESCRIPTION
Integrating work from @rsarwar87 (PR #594)

Enables compilation of the server, FSBL, U-Boot and Linux from a Docker container.

This solves the GLIBC compatibility problem when running Ubuntu 22.04 (issues #586, #542)

Run the make commands with `BUILD_METHOD=docker` to compile from the Docker container
