### PR TITLE
Python: Correctly detect socket closure, don't return partial data

### DIFF
--- a/python/koheron/koheron.py
+++ b/python/koheron/koheron.py
@@ -360,8 +360,8 @@ class KoheronClient:
         while n_rcv < n_bytes:
             try:
                 chunk = self.sock.recv(min(n_bytes - n_rcv, BUFF_SIZE))
-                if chunk == '':
-                    break
+                if not chunk:
+                    raise ConnectionError('recv_all: Socket connection broken.')
                 n_rcv += len(chunk)
                 data.append(chunk)
             except:


### PR DESCRIPTION
`if chunk == '':` did not detect socket closure correctly, because chunk is a bytestring and `b'' == ''` is False. On socket closure by the server, `recv_all()` would get stuck in a busy loop and consume memory without limit. Check `if not chunk:` instead.

In addition, raise an exception instead of returning partial data. Partial data is not useful to the caller, in the case of unexpected remote socket closure, better to raise an exception immediately than wait for calling code to raise exceptions about not being able to parse the partial data.