### PR TITLE
Python: catch narrower exception types

### DIFF
--- a/python/koheron/koheron.py
+++ b/python/koheron/koheron.py
@@ -248,14 +248,14 @@ class KoheronClient:
                 # Connect to Kserver
                 self.sock.connect((host, port))
                 self.is_connected = True
-            except BaseException as e:
+            except Exception as e:
                 raise ConnectionError('Failed to connect to {}:{} : {}'.format(host, port, e))
         elif unixsock != '':
             try:
                 self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                 self.sock.connect(unixsock)
                 self.is_connected = True
-            except BaseException as e:
+            except Exception as e:
                 raise ConnectionError('Failed to connect to unix socket address ' + unixsock)
         else:
             raise ValueError('Unknown socket type')
@@ -267,7 +267,7 @@ class KoheronClient:
     def check_version(self):
         try:
             self.send_command(1, 0)
-        except:
+        except Exception:
             raise ConnectionError('Failed to retrieve the server version')
         server_version = self.recv_string(check_type=False)
         server_version_ = server_version.split('.')
@@ -280,7 +280,7 @@ class KoheronClient:
     def load_devices(self):
         try:
             self.send_command(1, 1)
-        except:
+        except Exception:
             raise ConnectionError('Failed to send initialization command')
 
         self.commands = self.recv_json(check_type=False)
@@ -364,7 +364,7 @@ class KoheronClient:
                     break
                 n_rcv += len(chunk)
                 data.append(chunk)
-            except:
+            except Exception:
                 raise ConnectionError('recv_all: Socket connection broken.')
         return b''.join(data)
 


### PR DESCRIPTION
Catch `Exception`, instead of `BaseException` or using bare `except:` clauses.

This is still very broad, but avoids the case of catching `SystemExit` or `KeyboardInterrupt` (which are not subclasses of `Exception`) and re-raising them as `ConnectionError`.

Application code may handle `ConnectionError`s differently (such as attempting re-connection) to `SystemExit` or `KeyboardInterrupt`, which may be raised in signal handlers and which the application may treat as a relatively normal shutdown.