### PR TITLE
fix: early valid signals

### DIFF
--- a/examples/alpha15/adc-dac-dma/adc-dac-dma.hpp
+++ b/examples/alpha15/adc-dac-dma/adc-dac-dma.hpp
@@ -163,6 +163,10 @@ class AdcDacDma
         dma.write<Dma_regs::mm2s_taildesc>(mem::ocm_mm2s_addr + (n_desc-1) * 0x40);
         dma.write<Dma_regs::s2mm_taildesc>(mem::ocm_s2mm_addr + (n_desc-1) * 0x40);
 
+        // Wait for DMA to start before enabling tvalid
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        ps_ctl.set_bit<reg::en, 0>();
+        
         //log_dma();
         //log_hp0();
     }
@@ -172,6 +176,7 @@ class AdcDacDma
         dma.clear_bit<Dma_regs::s2mm_dmacr, 0>();
         dma.write<Dma_regs::mm2s_taildesc>(mem::ocm_mm2s_addr + (n_desc-1) * 0x40);
         dma.write<Dma_regs::s2mm_taildesc>(mem::ocm_s2mm_addr + (n_desc-1) * 0x40);
+        ps_ctl.clear_bit<reg::en, 0>();
     }
 
     auto& get_adc_data() {

--- a/examples/alpha15/adc-dac-dma/block_design.tcl
+++ b/examples/alpha15/adc-dac-dma/block_design.tcl
@@ -85,7 +85,6 @@ cell xilinx.com:ip:axis_dwidth_converter:1.1 axis_dwidth_converter_0 {
   aclk adc_dac/adc_clk
   aresetn rst_adc_clk/peripheral_aresetn
   s_axis_tdata adc_selector/tdata
-  s_axis_tvalid adc_selector/tvalid
 }
 
 cell xilinx.com:ip:axis_clock_converter:1.1 axis_clock_converter_0 {
@@ -132,6 +131,13 @@ cell xilinx.com:ip:axi_dma:7.1 axi_dma_0 {
   axi_resetn proc_sys_reset_0/peripheral_aresetn
   s2mm_introut [get_interrupt_pin]
   mm2s_introut [get_interrupt_pin]
+}
+
+cell koheron:user:tvalid_gen:1.0 tvalid_gen_0 {} {
+  valid adc_selector/tvalid
+  tready axi_dma_0/s_axis_s2mm_tready
+  en [ps_ctl_pin en]
+  tvalid axis_dwidth_converter_0/s_axis_tvalid
 }
 
 # DAC Streaming (MM2S)

--- a/examples/alpha15/adc-dac-dma/config.yml
+++ b/examples/alpha15/adc-dac-dma/config.yml
@@ -17,6 +17,7 @@ cores:
   - boards/alpha15/cores/ltc2387_v1_0
   - boards/alpha15/cores/dcdc_sync_v1_0
   - boards/alpha15/cores/mmcm_phase_shifter_v1_0
+  - ./tvalid_gen_v1_0
 
 memory:
   - name: control
@@ -76,6 +77,7 @@ ps_control_registers:
   - spi_cfg_data
   - spi_cfg_cmd
   - trig
+  - en
 
 ps_status_registers:
   - spi_cfg_sts

--- a/examples/alpha15/adc-dac-dma/tvalid_gen_v1_0/core_config.tcl
+++ b/examples/alpha15/adc-dac-dma/tvalid_gen_v1_0/core_config.tcl
@@ -1,0 +1,12 @@
+set display_name {tvalid gen}
+
+set core [ipx::current_core]
+
+set_property DISPLAY_NAME $display_name $core
+set_property DESCRIPTION $display_name $core
+
+set_property VENDOR {koheron} $core
+set_property VENDOR_DISPLAY_NAME {Koheron} $core
+set_property COMPANY_URL {http://www.koheron.com} $core
+
+

--- a/examples/alpha15/adc-dac-dma/tvalid_gen_v1_0/tvalid_gen.v
+++ b/examples/alpha15/adc-dac-dma/tvalid_gen_v1_0/tvalid_gen.v
@@ -1,0 +1,12 @@
+`timescale 1 ns / 1 ps
+
+module tvalid_gen(      
+    input   wire valid,     // adc_valid
+    input   wire tready,    // dma ready
+    input   wire en,        // ps ctl signal
+    output  wire tvalid     // axis valid 
+);
+
+    assign tvalid = tready && valid && en;
+
+endmodule


### PR DESCRIPTION
valid_gen module implemented to fix early valid signals being sent to the axi stream.

addresses #634  