### PR TITLE
Support per-region register lists in memory configs

### DIFF
--- a/examples/alpha15/adc-dac-bram/memory.yml
+++ b/examples/alpha15/adc-dac-bram/memory.yml
@@ -3,15 +3,33 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - mmcm
+    - precision_dac_ctl
+    - precision_dac_data[2]
+    - trig
+    - rf_adc_ctl[2]
+    - adp5071_sync
+    - digital_outputs_b34
+    - digital_outputs_b35_n
   - name: ps_control
     offset: '0x64000000'
     range: 4K
+    registers:
+    - spi_cfg_data
+    - spi_cfg_cmd
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - mmcm_sts
+    - adc[n_adc]
+    - digital_inputs_b35_p
   - name: ps_status
     offset: '0x54000000'
     range: 4K
+    registers:
+    - spi_cfg_sts
   - name: xadc
     offset: '0x43C00000'
     range: 64K
@@ -24,28 +42,6 @@ memory:
   - name: dac
     range: 128K
     offset: '0x40080000'
-
-control_registers:
-  - mmcm
-  - precision_dac_ctl
-  - precision_dac_data[2]
-  - trig
-  - rf_adc_ctl[2]
-  - adp5071_sync
-  - digital_outputs_b34
-  - digital_outputs_b35_n
-
-status_registers:
-  - mmcm_sts
-  - adc[n_adc]
-  - digital_inputs_b35_p
-
-ps_control_registers:
-  - spi_cfg_data
-  - spi_cfg_cmd
-
-ps_status_registers:
-  - spi_cfg_sts
 
 parameters:
   fclk0: 200000000 # CPU clock speed in Hz

--- a/examples/alpha15/adc-dac-dma/memory.yml
+++ b/examples/alpha15/adc-dac-dma/memory.yml
@@ -3,15 +3,31 @@ memory:
   - name: control
     offset: '0x40000000'
     range: 4K
+    registers:
+    - mmcm
+    - precision_dac_ctl
+    - precision_dac_data[2]
+    - rf_adc_ctl[2]
+    - adp5071_sync
+    - channel_select
+    - channel_offset[2]
   - name: ps_control
     offset: '0x54000000'
     range: 4K
+    registers:
+    - spi_cfg_data
+    - spi_cfg_cmd
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - mmcm_sts
+    - adc[n_adc]
   - name: ps_status
     offset: '0x58000000'
     range: 4K
+    registers:
+    - spi_cfg_sts
   - name: xadc
     offset: '0x43C00000'
     range: 64K
@@ -39,26 +55,6 @@ memory:
   - name: sclr
     offset: '0xF8000000'
     range: 64K
-
-control_registers:
-  - mmcm
-  - precision_dac_ctl
-  - precision_dac_data[2]
-  - rf_adc_ctl[2]
-  - adp5071_sync
-  - channel_select
-  - channel_offset[2]
-
-status_registers:
-  - mmcm_sts
-  - adc[n_adc]
-
-ps_control_registers:
-  - spi_cfg_data
-  - spi_cfg_cmd
-
-ps_status_registers:
-  - spi_cfg_sts
 
 parameters:
   fclk0: 143000000

--- a/examples/alpha15/decimator/memory.yml
+++ b/examples/alpha15/decimator/memory.yml
@@ -3,43 +3,39 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - mmcm
+    - precision_dac_ctl
+    - precision_dac_data[2]
+    - channel_select
+    - trig
+    - rf_adc_ctl[2]
+    - digital_outputs
+    - adp5071_sync
   - name: ps_control
     offset: '0x64000000'
     range: 4K
+    registers:
+    - spi_cfg_data
+    - spi_cfg_cmd
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - mmcm_sts
+    - adc[n_adc]
+    - digital_inputs
   - name: ps_status
     offset: '0x54000000'
     range: 4K
+    registers:
+    - spi_cfg_sts
   - name: xadc
     offset: '0x43C00000'
     range: 64K
   - name: adc_fifo
     offset: '0x43C10000'
     range: 64K
-
-control_registers:
-  - mmcm
-  - precision_dac_ctl
-  - precision_dac_data[2]
-  - channel_select
-  - trig
-  - rf_adc_ctl[2]
-  - digital_outputs
-  - adp5071_sync
-
-status_registers:
-  - mmcm_sts
-  - adc[n_adc]
-  - digital_inputs
-
-ps_control_registers:
-  - spi_cfg_data
-  - spi_cfg_cmd
-
-ps_status_registers:
-  - spi_cfg_sts
 
 parameters:
   fclk0: 166666667 # CPU clock speed in Hz

--- a/examples/alpha15/signal-analyzer/memory.yml
+++ b/examples/alpha15/signal-analyzer/memory.yml
@@ -3,15 +3,37 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - mmcm
+    - precision_dac_ctl
+    - precision_dac_data[2]
+    - trig
+    - rf_adc_ctl[2]
+    - digital_outputs
+    - adp5071_sync
+    - channel_select
+    - channel_offset[2]
   - name: ps_control
     offset: '0x64000000'
     range: 4K
+    registers:
+    - spi_cfg_data
+    - spi_cfg_cmd
+    - ctl_fft
+    - cic_rate[2]
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - mmcm_sts
+    - adc[n_adc]
+    - digital_inputs
   - name: ps_status
     offset: '0x54000000'
     range: 4K
+    registers:
+    - spi_cfg_sts
+    - cycle_index
   - name: xadc
     offset: '0x43C00000'
     range: 64K
@@ -40,32 +62,6 @@ memory:
   - name: axi_hp0
     offset: '0xF8008000'
     range: 4K
-
-control_registers:
-  - mmcm
-  - precision_dac_ctl
-  - precision_dac_data[2]
-  - trig
-  - rf_adc_ctl[2]
-  - digital_outputs
-  - adp5071_sync
-  - channel_select
-  - channel_offset[2]
-
-status_registers:
-  - mmcm_sts
-  - adc[n_adc]
-  - digital_inputs
-
-ps_control_registers:
-  - spi_cfg_data
-  - spi_cfg_cmd
-  - ctl_fft
-  - cic_rate[2]
-
-ps_status_registers:
-  - spi_cfg_sts
-  - cycle_index
 
 parameters:
   fclk0: 166666667 # CPU clock speed in Hz

--- a/examples/alpha15/vco/memory.yml
+++ b/examples/alpha15/vco/memory.yml
@@ -3,41 +3,37 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - mmcm
+    - precision_dac_ctl
+    - precision_dac_data[2]
+    - trig
+    - rf_adc_ctl[2]
+    - digital_outputs
+    - adp5071_sync
+    - phase_incr[4]
+    - vco_gain[2]
   - name: ps_control
     offset: '0x64000000'
     range: 4K
+    registers:
+    - spi_cfg_data
+    - spi_cfg_cmd
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - mmcm_sts
+    - adc[n_adc]
+    - digital_inputs
   - name: ps_status
     offset: '0x54000000'
     range: 4K
+    registers:
+    - spi_cfg_sts
   - name: xadc
     offset: '0x43C00000'
     range: 64K
-
-control_registers:
-  - mmcm
-  - precision_dac_ctl
-  - precision_dac_data[2]
-  - trig
-  - rf_adc_ctl[2]
-  - digital_outputs
-  - adp5071_sync
-  - phase_incr[4]
-  - vco_gain[2]
-
-status_registers:
-  - mmcm_sts
-  - adc[n_adc]
-  - digital_inputs
-
-ps_control_registers:
-  - spi_cfg_data
-  - spi_cfg_cmd
-
-ps_status_registers:
-  - spi_cfg_sts
 
 parameters:
   fclk0: 200000000

--- a/examples/alpha250-4/adc-bram/memory.yml
+++ b/examples/alpha250-4/adc-bram/memory.yml
@@ -3,15 +3,25 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - mmcm
+    - precision_dac_ctl
+    - precision_dac_data[2]
+    - trig
   - name: ps_control
     offset: '0x64000000'
     range: 4K
+    registers:
+    - spi_cfg_data
+    - spi_cfg_cmd
   - name: status
     offset: '0x50000000'
     range: 4K
   - name: ps_status
     offset: '0x54000000'
     range: 4K
+    registers:
+    - spi_cfg_sts
   - name: xadc
     offset: '0x43C00000'
     range: 64K
@@ -21,19 +31,6 @@ memory:
   - name: adc1
     range: 256K
     offset: '0x40040000'
-
-control_registers:
-  - mmcm
-  - precision_dac_ctl
-  - precision_dac_data[2]
-  - trig
-
-ps_control_registers:
-  - spi_cfg_data
-  - spi_cfg_cmd
-
-ps_status_registers:
-  - spi_cfg_sts
 
 parameters:
   fclk0: 200000000 # FPGA clock speed in Hz

--- a/examples/alpha250-4/fft/memory.yml
+++ b/examples/alpha250-4/fft/memory.yml
@@ -3,15 +3,33 @@ memory:
   - name: control
     offset: '0x40000000'
     range: 4K
+    registers:
+    - mmcm
+    - precision_dac_ctl
+    - precision_dac_data[2]
+    - ctl_fft[2]
+    - psd_valid[2]
+    - psd_input_sel[2]
+    - digital_outputs
   - name: ps_control
     offset: '0x44000000'
     range: 4K
+    registers:
+    - spi_cfg_data
+    - spi_cfg_cmd
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - adc0[n_adc]
+    - adc1[n_adc]
+    - cycle_index[2]
+    - digital_inputs
   - name: ps_status
     offset: '0x54000000'
     range: 4K
+    registers:
+    - spi_cfg_sts
   - name: xadc
     offset: '0x43C00000'
     range: 64K
@@ -27,28 +45,6 @@ memory:
   - name: psd1
     offset: '0x63000000'
     range: 32K
-
-control_registers:
-  - mmcm
-  - precision_dac_ctl
-  - precision_dac_data[2]
-  - ctl_fft[2]
-  - psd_valid[2]
-  - psd_input_sel[2]
-  - digital_outputs
-
-ps_control_registers:
-  - spi_cfg_data
-  - spi_cfg_cmd
-
-status_registers:
-  - adc0[n_adc]
-  - adc1[n_adc]
-  - cycle_index[2]
-  - digital_inputs
-
-ps_status_registers:
-  - spi_cfg_sts
 
 parameters:
   fclk0: 200000000

--- a/examples/alpha250/adc-dac-bram/memory.yml
+++ b/examples/alpha250/adc-dac-bram/memory.yml
@@ -3,15 +3,27 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - mmcm
+    - precision_dac_ctl
+    - precision_dac_data[2]
+    - trig
   - name: ps_control
     offset: '0x64000000'
     range: 4K
+    registers:
+    - spi_cfg_data
+    - spi_cfg_cmd
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - adc[n_adc]
   - name: ps_status
     offset: '0x54000000'
     range: 4K
+    registers:
+    - spi_cfg_sts
   - name: xadc
     offset: '0x43C00000'
     range: 64K
@@ -21,22 +33,6 @@ memory:
   - name: dac
     range: 256K
     offset: '0x40040000'
-
-control_registers:
-  - mmcm
-  - precision_dac_ctl
-  - precision_dac_data[2]
-  - trig
-
-status_registers:
-  - adc[n_adc]
-
-ps_control_registers:
-  - spi_cfg_data
-  - spi_cfg_cmd
-
-ps_status_registers:
-  - spi_cfg_sts
 
 parameters:
   fclk0: 200000000 # FPGA clock speed in Hz

--- a/examples/alpha250/adc-dac-dma/memory.yml
+++ b/examples/alpha250/adc-dac-dma/memory.yml
@@ -3,15 +3,27 @@ memory:
   - name: control
     offset: '0x40000000'
     range: 4K
+    registers:
+    - mmcm
+    - precision_dac_ctl
+    - precision_dac_data[2]
+    - channel_select
   - name: ps_control
     offset: '0x54000000'
     range: 4K
+    registers:
+    - spi_cfg_data
+    - spi_cfg_cmd
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - adc[n_adc]
   - name: ps_status
     offset: '0x58000000'
     range: 4K
+    registers:
+    - spi_cfg_sts
   - name: xadc
     offset: '0x43C00000'
     range: 64K
@@ -39,22 +51,6 @@ memory:
   - name: sclr
     offset: '0xF8000000'
     range: 64K
-
-control_registers:
-  - mmcm
-  - precision_dac_ctl
-  - precision_dac_data[2]
-  - channel_select
-
-status_registers:
-  - adc[n_adc]
-
-ps_control_registers:
-  - spi_cfg_data
-  - spi_cfg_cmd
-
-ps_status_registers:
-  - spi_cfg_sts
 
 parameters:
   fclk0: 143000000

--- a/examples/alpha250/dpll/memory.yml
+++ b/examples/alpha250/dpll/memory.yml
@@ -3,15 +3,35 @@ memory:
   - name: control
     offset: '0x40000000'
     range: 4K
+    registers:
+    - mmcm
+    - precision_dac_ctl
+    - precision_dac_data[2]
+    - phase_incr[4]
+    - p_gain[2]
+    - pi_gain[2]
+    - i2_gain[2]
+    - i3_gain[2]
+    - integrators[2]
+    - dac_sel
+    - phase_sel
+    - cic_rate
   - name: ps_control
     offset: '0x64000000'
     range: 4K
+    registers:
+    - spi_cfg_data
+    - spi_cfg_cmd
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - adc[n_adc]
   - name: ps_status
     offset: '0x54000000'
     range: 4K
+    registers:
+    - spi_cfg_sts
   - name: xadc
     offset: '0x43C00000'
     range: 64K
@@ -24,30 +44,6 @@ memory:
   - name: axi_hp0
     offset: '0xF8008000'
     range: 4K
-
-control_registers:
-  - mmcm
-  - precision_dac_ctl
-  - precision_dac_data[2]
-  - phase_incr[4]
-  - p_gain[2]
-  - pi_gain[2]
-  - i2_gain[2]
-  - i3_gain[2]
-  - integrators[2]
-  - dac_sel
-  - phase_sel
-  - cic_rate
-
-ps_control_registers:
-  - spi_cfg_data
-  - spi_cfg_cmd
-
-status_registers:
-  - adc[n_adc]
-
-ps_status_registers:
-  - spi_cfg_sts
 
 parameters:
   fclk0: 200000000

--- a/examples/alpha250/fft/memory.yml
+++ b/examples/alpha250/fft/memory.yml
@@ -3,15 +3,33 @@ memory:
   - name: control
     offset: '0x40000000'
     range: 4K
+    registers:
+    - mmcm
+    - precision_dac_ctl
+    - precision_dac_data[2]
+    - ctl_fft
+    - psd_valid
+    - psd_input_sel
+    - phase_incr[2]
+    - digital_outputs
   - name: ps_control
     offset: '0x44000000'
     range: 4K
+    registers:
+    - spi_cfg_data
+    - spi_cfg_cmd
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - adc[n_adc]
+    - cycle_index
+    - digital_inputs
   - name: ps_status
     offset: '0x55000000'
     range: 4K
+    registers:
+    - spi_cfg_sts
   - name: xadc
     offset: '0x43C00000'
     range: 64K
@@ -23,28 +41,6 @@ memory:
     offset: '0x70000000'
     range: 32K
     dev: '/dev/mem_wc'
-
-control_registers:
-  - mmcm
-  - precision_dac_ctl
-  - precision_dac_data[2]
-  - ctl_fft
-  - psd_valid
-  - psd_input_sel
-  - phase_incr[2]
-  - digital_outputs
-
-status_registers:
-  - adc[n_adc]
-  - cycle_index
-  - digital_inputs
-
-ps_control_registers:
-  - spi_cfg_data
-  - spi_cfg_cmd
-
-ps_status_registers:
-  - spi_cfg_sts
 
 parameters:
   fclk0: 200000000

--- a/examples/alpha250/loopback/memory.yml
+++ b/examples/alpha250/loopback/memory.yml
@@ -3,33 +3,29 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - mmcm
+    - precision_dac_ctl
+    - precision_dac_data[2]
   - name: ps_control
     offset: '0x64000000'
     range: 4K
+    registers:
+    - spi_cfg_data
+    - spi_cfg_cmd
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - adc[n_adc]
   - name: ps_status
     offset: '0x54000000'
     range: 4K
+    registers:
+    - spi_cfg_sts
   - name: xadc
     offset: '0x43C00000'
     range: 64K
-
-control_registers:
-  - mmcm
-  - precision_dac_ctl
-  - precision_dac_data[2]
-
-status_registers:
-  - adc[n_adc]
-
-ps_control_registers:
-  - spi_cfg_data
-  - spi_cfg_cmd
-
-ps_status_registers:
-  - spi_cfg_sts
 
 parameters:
   fclk0: 200000000 # FPGA clock speed in Hz

--- a/examples/alpha250/phase-noise-analyzer/memory.yml
+++ b/examples/alpha250/phase-noise-analyzer/memory.yml
@@ -3,15 +3,30 @@ memory:
   - name: control
     offset: '0x40000000'
     range: 4K
+    registers:
+    - mmcm
+    - precision_dac_ctl
+    - precision_dac_data[2]
+    - phase_incr[4]
+    - cordic
+    - cic_rate
   - name: ps_control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - spi_cfg_data
+    - spi_cfg_cmd
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - adc[n_adc]
+    - demod[n_adc]
   - name: ps_status
     offset: '0x70000000'
     range: 4K
+    registers:
+    - spi_cfg_sts
   - name: xadc
     offset: '0x43C00000'
     range: 64K
@@ -26,25 +41,6 @@ memory:
   - name: axi_hp0
     offset: '0xF8008000'
     range: 4K
-
-control_registers:
-  - mmcm
-  - precision_dac_ctl
-  - precision_dac_data[2]
-  - phase_incr[4]
-  - cordic
-  - cic_rate
-
-status_registers:
-  - adc[n_adc]
-  - demod[n_adc]
-
-ps_control_registers:
-  - spi_cfg_data
-  - spi_cfg_cmd
-
-ps_status_registers:
-  - spi_cfg_sts
 
 parameters:
   fclk0: 200000000

--- a/examples/alpha250/vco/memory.yml
+++ b/examples/alpha250/vco/memory.yml
@@ -3,35 +3,31 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - mmcm
+    - precision_dac_ctl
+    - precision_dac_data[2]
+    - phase_incr[4]
+    - vco_gain[2]
   - name: ps_control
     offset: '0x64000000'
     range: 4K
+    registers:
+    - spi_cfg_data
+    - spi_cfg_cmd
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - adc[n_adc]
   - name: ps_status
     offset: '0x54000000'
     range: 4K
+    registers:
+    - spi_cfg_sts
   - name: xadc
     offset: '0x43C00000'
     range: 64K
-
-control_registers:
-  - mmcm
-  - precision_dac_ctl
-  - precision_dac_data[2]
-  - phase_incr[4]
-  - vco_gain[2]
-
-status_registers:
-  - adc[n_adc]
-
-ps_control_registers:
-  - spi_cfg_data
-  - spi_cfg_cmd
-
-ps_status_registers:
-  - spi_cfg_sts
 
 parameters:
   fclk0: 200000000 # FPGA clock speed in Hz

--- a/examples/red-pitaya/adc-dac-bram/memory.yml
+++ b/examples/red-pitaya/adc-dac-bram/memory.yml
@@ -3,9 +3,14 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - led
+    - trig
   - name: status
     offset: '0x50001000'
     range: 4K
+    registers:
+    - reg1
   - name: xadc
     offset: '0x43C00000'
     range: 64K
@@ -15,13 +20,6 @@ memory:
   - name: dac
     range: 64K
     offset: '0x40040000'
-
-control_registers:
-  - led
-  - trig
-
-status_registers:
-  - reg1
 
 parameters:
   fclk0: 200000000 # FPGA clock speed in Hz

--- a/examples/red-pitaya/adc-dac/memory.yml
+++ b/examples/red-pitaya/adc-dac/memory.yml
@@ -3,16 +3,14 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - led
+    - dac[n_dac]
   - name: status
     offset: '0x50000000'
     range: 4K
-
-control_registers:
-  - led
-  - dac[n_dac]
-
-status_registers:
-  - adc[n_adc]
+    registers:
+    - adc[n_adc]
 
 parameters:
   fclk0: 200000000

--- a/examples/red-pitaya/cluster/memory.yml
+++ b/examples/red-pitaya/cluster/memory.yml
@@ -3,24 +3,22 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - led
+    - phase_incr[2]
+    - ctl_sata
+    - pulse_width
+    - pulse_period
+    - trigger
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - adc[n_adc]
+    - sts_sata
   - name: ctl_clk
     offset: '0x70000000'
     range: 4K
-
-control_registers:
-  - led
-  - phase_incr[2]
-  - ctl_sata
-  - pulse_width
-  - pulse_period
-  - trigger
-
-status_registers:
-  - adc[n_adc]
-  - sts_sata
 
 parameters:
   fclk0: 200000000

--- a/examples/red-pitaya/decimator/memory.yml
+++ b/examples/red-pitaya/decimator/memory.yml
@@ -3,19 +3,17 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - led
+    - dac[n_dac]
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - adc[n_adc]
   - name: adc_fifo
     offset: '0x43C10000'
     range: 64K
-
-control_registers:
-  - led
-  - dac[n_dac]
-
-status_registers:
-  - adc[n_adc]
 
 parameters:
   fclk0: 166666667

--- a/examples/red-pitaya/dual-dds/memory.yml
+++ b/examples/red-pitaya/dual-dds/memory.yml
@@ -3,16 +3,14 @@ memory:
   - name: control
     offset: '0x40000000'
     range: 4K
+    registers:
+    - led
+    - phase_incr[4]
   - name: status
     offset: '0x50000000'
     range: 4K
-
-control_registers:
-  - led
-  - phase_incr[4]
-
-status_registers:
-  - adc[n_adc]
+    registers:
+    - adc[n_adc]
 
 parameters:
   fclk0: 200000000

--- a/examples/red-pitaya/fft/memory.yml
+++ b/examples/red-pitaya/fft/memory.yml
@@ -3,9 +3,25 @@ memory:
   - name: control
     offset: '0x40000000'
     range: 4K
+    registers:
+    - led
+    - mmcm
+    - ctl_fft
+    - psd_valid
+    - psd_input_sel
+    - phase_incr[2]
+    - laser_current
+    - laser_control
+    - power_setpoint
+    - eeprom_ctl
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - adc[n_adc]
+    - cycle_index
+    - eeprom_sts
+    - pid_control
   - name: xadc
     offset: '0x43C00000'
     range: 64K
@@ -18,24 +34,6 @@ memory:
   - name: adc_fifo
     offset: '0x43C10000'
     range: 32K
-
-control_registers:
-  - led
-  - mmcm
-  - ctl_fft
-  - psd_valid
-  - psd_input_sel
-  - phase_incr[2]
-  - laser_current
-  - laser_control
-  - power_setpoint
-  - eeprom_ctl
-
-status_registers:
-  - adc[n_adc]
-  - cycle_index
-  - eeprom_sts
-  - pid_control
 
 parameters:
   fclk0: 187500000

--- a/examples/red-pitaya/laser-controller/memory.yml
+++ b/examples/red-pitaya/laser-controller/memory.yml
@@ -19,26 +19,24 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - led
+    - laser_current
+    - laser_control
+    - power_setpoint
+    - dac[n_dac]
+    - eeprom_ctl
   - name: status
     offset: '0x50000000'
     range: 4K
     protection: read
+    registers:
+    - adc[n_adc]
+    - pid_control
+    - eeprom_sts
   - name: xadc
     offset: '0x43C00000'
     range: 64K
-
-control_registers:
-  - led
-  - laser_current
-  - laser_control
-  - power_setpoint
-  - dac[n_dac]
-  - eeprom_ctl
-
-status_registers:
-  - adc[n_adc]
-  - pid_control
-  - eeprom_sts
 
 parameters:
   fclk0: 200000000

--- a/examples/red-pitaya/led-blinker/memory.yml
+++ b/examples/red-pitaya/led-blinker/memory.yml
@@ -3,15 +3,13 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - led
   - name: status
     offset: '0x50000000'
     range: 4K
-
-control_registers:
-  - led
-
-status_registers:
-  - forty_two
+    registers:
+    - forty_two
 
 parameters:
   fclk0: 50000000 # FPGA clock speed in Hz

--- a/examples/red-pitaya/phase-noise-analyzer/memory.yml
+++ b/examples/red-pitaya/phase-noise-analyzer/memory.yml
@@ -3,9 +3,15 @@ memory:
   - name: control
     offset: '0x40000000'
     range: 4K
+    registers:
+    - led
+    - phase_incr[4]
+    - cordic
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - adc[n_adc]
   - name: xadc
     offset: '0x43C00000'
     range: 64K
@@ -18,14 +24,6 @@ memory:
   - name: axi_hp0
     offset: '0xF8008000'
     range: 4K
-
-control_registers:
-  - led
-  - phase_incr[4]
-  - cordic
-
-status_registers:
-  - adc[n_adc]
 
 parameters:
   fclk0: 125000000

--- a/examples/red-pitaya/pulse-generator/memory.yml
+++ b/examples/red-pitaya/pulse-generator/memory.yml
@@ -3,25 +3,23 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - led
+    - trigger
+    - pulse_width
+    - pulse_period
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - adc[n_adc]
+    - count
   - name: dac
     offset: '0x40000000'
     range: 32K
   - name: adc_fifo
     offset: '0x43C10000'
     range: 64K
-
-control_registers:
-  - led
-  - trigger
-  - pulse_width
-  - pulse_period
-
-status_registers:
-  - adc[n_adc]
-  - count
 
 parameters:
   fclk0: 166666667

--- a/examples/zedboard/led-blinker/memory.yml
+++ b/examples/zedboard/led-blinker/memory.yml
@@ -3,15 +3,13 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - led
   - name: status
     offset: '0x50000000'
     range: 4K
-
-control_registers:
-  - led
-
-status_registers:
-  - forty_two
+    registers:
+    - forty_two
 
 parameters:
   fclk0: 50000000 # FPGA clock speed in Hz

--- a/examples/zedboard/picoblaze/memory.yml
+++ b/examples/zedboard/picoblaze/memory.yml
@@ -3,20 +3,18 @@ memory:
   - name: control
     offset: '0x60000000'
     range: 4K
+    registers:
+    - led
+    - in_port
+    - reset
   - name: status
     offset: '0x50000000'
     range: 4K
+    registers:
+    - out_port
   - name: picoram
     offset: '0x40000000'
     range: 4K
-
-control_registers:
-  - led
-  - in_port
-  - reset
-
-status_registers:
-  - out_port
 
 parameters:
   fclk0: 50000000 # FPGA clock speed in Hz

--- a/fpga/lib/ctl_sts.tcl
+++ b/fpga/lib/ctl_sts.tcl
@@ -1,13 +1,18 @@
 proc add_ctl_sts {{mclk "None"}  {mrstn "None"}} {
-  add_config_register ctl control $mclk $mrstn config::ctl_register $config::control_size
-  add_status_register sts status $mclk $mrstn config::sts_register $config::status_size
-
-  if {$config::ps_control_size > 0} {
-    add_config_register ps_ctl ps_control "None" "None" config::ps_ctl_register $config::ps_control_size
+  if {[info exists config::register_count_control] && $config::register_count_control > 0} {
+    add_config_register ctl control $mclk $mrstn config::register_control $config::register_count_control
   }
 
-  if {$config::ps_status_size > 0} {
-    add_status_register ps_sts ps_status "None" "None" config::ps_sts_register $config::ps_status_size 0 0
+  if {[info exists config::register_count_status] && $config::register_count_status > 0} {
+    add_status_register sts status $mclk $mrstn config::register_status $config::register_count_status
+  }
+
+  if {[info exists config::register_count_ps_control] && $config::register_count_ps_control > 0} {
+    add_config_register ps_ctl ps_control "None" "None" config::register_ps_control $config::register_count_ps_control
+  }
+
+  if {[info exists config::register_count_ps_status] && $config::register_count_ps_status > 0} {
+    add_status_register ps_sts ps_status "None" "None" config::register_ps_status $config::register_count_ps_status 0 0
   }
 }
 

--- a/fpga/memory.tcl
+++ b/fpga/memory.tcl
@@ -1,44 +1,15 @@
 namespace eval config {
 
 ##########################################################
-# Define control offsets
+# Define register offsets
 ##########################################################
-variable ctl_register
-{% for name in config['control_registers'] -%}
-set ctl_register({{ loop.index0 }}) {{name}}
+{% for address in config['memory'] if address['registers'] -%}
+variable register_{{ address['name'] }}
+{% for name in address['registers'] -%}
+set register_{{ address['name'] }}({{ loop.index0 }}) {{name}}
 {% endfor -%}
-
-variable control_size {{ config['control_registers'] | length }}
-
-##########################################################
-# Define ps control offsets
-##########################################################
-variable ps_ctl_register
-{% for name in config['ps_control_registers'] -%}
-set ps_ctl_register({{ loop.index0 }}) {{name}}
+variable register_count_{{ address['name'] }} {{ address['register_count'] }}
 {% endfor -%}
-
-variable ps_control_size {{ config['ps_control_registers'] | length }}
-
-##########################################################
-# Define status offsets
-##########################################################
-variable sts_register
-{% for name in config['status_registers'] -%}
-set sts_register({{ loop.index0 }}) {{name}}
-{% endfor -%}
-
-variable status_size {{ config['status_registers'] | length }}
-
-##########################################################
-# Define ps status offsets
-##########################################################
-variable ps_sts_register
-{% for name in config['ps_status_registers'] -%}
-set ps_sts_register({{ loop.index0 }}) {{name}}
-{% endfor -%}
-
-variable ps_status_size {{ config['ps_status_registers'] | length }}
 
 ##########################################################
 # Define parameters

--- a/make.py
+++ b/make.py
@@ -73,6 +73,11 @@ def build_memory(memory, parameters):
         elif address['dev'] == '/dev/mem_wc':
             address['dev'] = address['dev'] + address['offset']
 
+        registers = address.get('registers', []) or []
+        registers = build_registers(registers, parameters) if registers else []
+        address['registers'] = registers
+        address['register_count'] = len(registers)
+
     return memory
 
 def build_registers(registers, parameters):
@@ -93,10 +98,6 @@ def build_registers(registers, parameters):
 def append_memory_to_config(config):
     parameters = config.get('parameters', {})
     config['memory'] = build_memory(config.get('memory', {}), parameters)
-    config['control_registers'] = build_registers(config.get('control_registers', {}), parameters)
-    config['ps_control_registers'] = build_registers(config.get('ps_control_registers', {}), parameters)
-    config['status_registers'] = build_registers(config.get('status_registers', {}), parameters)
-    config['ps_status_registers'] = build_registers(config.get('ps_status_registers', {}), parameters)
     return config
 
 def build_json(dict):

--- a/server/templates/memory.hpp
+++ b/server/templates/memory.hpp
@@ -39,25 +39,12 @@ constexpr std::array<std::tuple<uintptr_t, uint32_t, uint32_t, uint32_t, std::st
 } // namespace mem
 
 namespace reg {
-// -- Control offsets
-{% for offset in config['control_registers'] -%}
+{% for addr in config['memory'] if addr['registers'] -%}
+// -- {{ addr['name'] }} offsets
+{% for offset in addr['registers'] -%}
 constexpr uint32_t {{ offset }} = {{ 4 * loop.index0 }};
-static_assert({{ offset }} < mem::control_range, "Invalid control register offset {{ offset }}");
+static_assert({{ 4 * loop.index0 }} < mem::{{ addr['name'] }}_range, "Invalid {{ addr['name'] }} register offset {{ offset }}");
 {% endfor %}
-// -- PS Control offsets
-{% for offset in config['ps_control_registers'] -%}
-constexpr uint32_t {{ offset }} = {{ 4 * loop.index0 }};
-static_assert({{ offset }} < mem::ps_control_range, "Invalid ps control register offset {{ offset }}");
-{% endfor %}
-// -- Status offsets
-{% for offset in config['status_registers'] -%}
-constexpr uint32_t {{ offset }} = {{ 4 * loop.index0 }};
-static_assert({{ offset }} < mem::status_range, "Invalid status register offset {{ offset }}");
-{% endfor %}
-// -- PS Status offsets
-{% for offset in config['ps_status_registers'] -%}
-constexpr uint32_t {{ offset }} = {{ 4 * loop.index0 }};
-static_assert({{ offset }} < mem::ps_status_range, "Invalid ps status register offset {{ offset }}");
 {% endfor %}
 
 constexpr uint32_t dna = 0;


### PR DESCRIPTION
## Summary
- define register lists within each memory region across the memory.yml files
- update the Python helpers and code generation templates to consume the per-region register metadata

## Testing
- python3 make.py --memory_hpp /tmp/memory.hpp examples/alpha15/decimator/memory.yml
- python3 make.py --memory_tcl /tmp/memory.tcl examples/alpha15/decimator/memory.yml
- python3 make.py --memory_hpp /tmp/memory_rp.hpp examples/red-pitaya/decimator/memory.yml

------
https://chatgpt.com/codex/tasks/task_b_68e7c55cf3748326957bd54e9c7ce0ff