### PR TITLE
Add support for .mem files in BRAM initialization

### DIFF
--- a/fpga/vivado/core.tcl
+++ b/fpga/vivado/core.tcl
@@ -21,6 +21,13 @@ if {[llength testbench_files] > 0} {
   remove_files $testbench_files
 }
 
+# Add .mem files for BRAM initialization (used by XPM_MEMORY)
+set mem_files [glob -nocomplain $core_path/*.mem]
+if {[llength $mem_files] > 0} {
+  add_files -norecurse $mem_files
+  puts "Added [llength $mem_files] .mem file(s) for BRAM initialization"
+}
+
 ipx::package_project -import_files -root_dir $output_path/$core_name
 
 set core [ipx::current_core]


### PR DESCRIPTION
This change allows XPM_MEMORY cores to use .mem files for BRAM initialization by automatically detecting and adding them during the IP packaging process.