### PR TITLE
Fix WebSocket pool socket leak and empty payload crash

### DIFF
--- a/web/koheron.ts
+++ b/web/koheron.ts
@@ -456,15 +456,19 @@ class Client {
             len = dv.byteLength - 8;
             buffer = new ArrayBuffer(len);
             dvBuff = new DataView(buffer);
-            for (i = 0, end = len-1, asc = 0 <= end; asc ? i <= end : i >= end; asc ? i++ : i--) { var asc, end;
-            dvBuff.setUint8(i, dv.getUint8(8 + i)); }
+            if (len > 0) {
+                for (i = 0, end = len-1, asc = 0 <= end; asc ? i <= end : i >= end; asc ? i++ : i--) { var asc, end;
+                dvBuff.setUint8(i, dv.getUint8(8 + i)); }
+            }
         } else { // 'dynamic'
             len = dv.getUint32(8);
             console.assert(dv.byteLength === (len + 12));
             buffer = new ArrayBuffer(len);
             dvBuff = new DataView(buffer);
-            for (i = 0, end1 = len-1, asc1 = 0 <= end1; asc1 ? i <= end1 : i >= end1; asc1 ? i++ : i--) { var asc1, end1;
-            dvBuff.setUint8(i, dv.getUint8(12 + i)); }
+            if (len > 0) {
+                for (i = 0, end1 = len-1, asc1 = 0 <= end1; asc1 ? i <= end1 : i >= end1; asc1 ? i++ : i--) { var asc1, end1;
+                dvBuff.setUint8(i, dv.getUint8(12 + i)); }
+            }
         }
 
         return [dvBuff, classId, funcId];
@@ -481,7 +485,11 @@ class Client {
             websocket.send(cmd.data);
 
             websocket.onmessage = evt => {
-                fn(this.getPayload(mode, evt)[0]);
+                try {
+                    fn(this.getPayload(mode, evt)[0]);
+                } catch (e) {
+                    console.warn('_readBase error, received', evt.data.byteLength, 'bytes, mode:', mode, e);
+                }
 
                 if (this.websockpool !== null && typeof this.websockpool !== 'undefined') {
                     this.websockpool.freeSocket(sockid);


### PR DESCRIPTION
## Summary

- **Socket leak fix (`_readBase`):** When `getPayload()` throws (e.g. `DataView RangeError` on truncated WebSocket responses), `freeSocket()` was never called, permanently leaking the socket from the pool. Over time this exhausts all available sockets and the web interface freezes. Added try/catch around the callback so `freeSocket()` is always called.

- **Empty payload fix (`getPayload`):** The CoffeeScript-generated `for` loop executes one spurious iteration when `len=0` (empty vector response), causing out-of-bounds `DataView` access. Added `if (len > 0)` guard before both copy loops (static and dynamic branches).

## Test plan

- [ ] Verify web interface works normally after the change
- [ ] Simulate truncated WebSocket responses and verify sockets are reclaimed instead of leaked
- [ ] Send a command returning an empty vector and verify no out-of-bounds crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)