### PR TITLE
docker: mount PROJECT_PATH for out-of-tree builds

### DIFF
--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -4,7 +4,7 @@ ifeq ($(BUILD_METHOD),docker)
 	GID = $(shell id -g)
 	DOCKER = docker run --rm \
 		-v $(SDK_FULL_PATH):/home/containeruser/wkspace:Z \
-		-v $(PROJECT_PATH):$(PROJECT_PATH):Z \
+		-v $(abspath $(PROJECT_PATH)):/home/containeruser/project:Z \
 		-u $(UID):$(GID) \
 		-w /home/containeruser/wkspace \
 		gnu-gcc-9.5

--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -2,5 +2,10 @@ DOCKER :=
 ifeq ($(BUILD_METHOD),docker)
 	UID = $(shell id -u)
 	GID = $(shell id -g)
-	DOCKER = docker run --rm -v $(SDK_FULL_PATH):/home/containeruser/wkspace:Z -u $(UID):$(GID) -w /home/containeruser/wkspace gnu-gcc-9.5
+	DOCKER = docker run --rm \
+		-v $(SDK_FULL_PATH):/home/containeruser/wkspace:Z \
+		-v $(PROJECT_PATH):$(PROJECT_PATH):Z \
+		-u $(UID):$(GID) \
+		-w /home/containeruser/wkspace \
+		gnu-gcc-9.5
 endif


### PR DESCRIPTION
## Summary

When `CONFIG` points to a project directory **outside** the SDK tree (e.g. a standalone instrument repo that delegates to the SDK via `make -C`), the Docker cross-compilation container fails because it can only see `SDK_FULL_PATH`.

This adds a second bind-mount for `$(PROJECT_PATH)` (derived from `$(dir $(CONFIG))` in the main Makefile). When the project lives inside the SDK, this is a no-op — Docker silently ignores mounting a subdirectory of an already-mounted path.

## Changes

- `docker/docker.mk`: add `-v $(PROJECT_PATH):$(PROJECT_PATH):Z` to the `docker run` command

## Notes

The V1 branch has the same limitation in its rewritten `docker.mk` (`DOCKER_VOL` only mounts `SDK_FULL_PATH`).