### PR TITLE
Fix socket leak in web UI when server returns empty vectors

### DIFF
--- a/web/koheron.ts
+++ b/web/koheron.ts
@@ -478,26 +478,24 @@ class Client {
         if ((this.websockpool === null || typeof(this.websockpool) === 'undefined')) {
             return fn(null);
         }
-
-        this.websockpool.requestSocket( sockid => {
+    
+        this.websockpool.requestSocket(sockid => {
             if (sockid < 0) { return fn(null); }
             let websocket = this.websockpool.getSocket(sockid);
             websocket.send(cmd.data);
-
+    
             websocket.onmessage = evt => {
                 try {
                     fn(this.getPayload(mode, evt)[0]);
-                } catch (e) {
-                    console.warn('_readBase error, received', evt.data.byteLength, 'bytes, mode:', mode, e);
-                }
-
-                if (this.websockpool !== null && typeof this.websockpool !== 'undefined') {
-                    this.websockpool.freeSocket(sockid);
+                } finally {
+                    if (this.websockpool !== null && typeof this.websockpool !== 'undefined') {
+                        this.websockpool.freeSocket(sockid);
+                    }
                 }
             };
         });
     }
-
+    
     readUint32Array(cmd: CmdMessage, fn: (x: Uint32Array) => void): void {
         this._readBase('static', cmd, (data) => {
             fn(new Uint32Array(data.buffer));

--- a/web/koheron.ts
+++ b/web/koheron.ts
@@ -456,15 +456,19 @@ class Client {
             len = dv.byteLength - 8;
             buffer = new ArrayBuffer(len);
             dvBuff = new DataView(buffer);
-            for (i = 0, end = len-1, asc = 0 <= end; asc ? i <= end : i >= end; asc ? i++ : i--) { var asc, end;
-            dvBuff.setUint8(i, dv.getUint8(8 + i)); }
+            if (len > 0) {
+                for (i = 0, end = len-1, asc = 0 <= end; asc ? i <= end : i >= end; asc ? i++ : i--) { var asc, end;
+                dvBuff.setUint8(i, dv.getUint8(8 + i)); }
+            }
         } else { // 'dynamic'
             len = dv.getUint32(8);
             console.assert(dv.byteLength === (len + 12));
             buffer = new ArrayBuffer(len);
             dvBuff = new DataView(buffer);
-            for (i = 0, end1 = len-1, asc1 = 0 <= end1; asc1 ? i <= end1 : i >= end1; asc1 ? i++ : i--) { var asc1, end1;
-            dvBuff.setUint8(i, dv.getUint8(12 + i)); }
+            if (len > 0) {
+                for (i = 0, end1 = len-1, asc1 = 0 <= end1; asc1 ? i <= end1 : i >= end1; asc1 ? i++ : i--) { var asc1, end1;
+                dvBuff.setUint8(i, dv.getUint8(12 + i)); }
+            }
         }
 
         return [dvBuff, classId, funcId];
@@ -481,7 +485,11 @@ class Client {
             websocket.send(cmd.data);
 
             websocket.onmessage = evt => {
-                fn(this.getPayload(mode, evt)[0]);
+                try {
+                    fn(this.getPayload(mode, evt)[0]);
+                } catch (e) {
+                    console.warn('_readBase error, received', evt.data.byteLength, 'bytes, mode:', mode, e);
+                }
 
                 if (this.websockpool !== null && typeof this.websockpool !== 'undefined') {
                     this.websockpool.freeSocket(sockid);


### PR DESCRIPTION
The  `for` loop in `getPayload()` does one iteration even when `len=0` (empty `std::vector` from the server). This may cause an exception in the `onmessage` callback which wouldn't be catched and fail silently. Since `freeSocket()` comes after the callback, in this case, it never runs and the socket is permanently lost from the pool.

Any polling pattern where the server regularly returns empty vectors drains the pool of sockets after a while, then the whole web UI freezes.

**Fix (2 changes in `koheron.ts`):**
- Guard the byte-copy loops with `if (len > 0)` so empty payloads don't crash
- Wrap the `onmessage` callback in `try/catch` so `freeSocket()` always runs, even on unexpected errors