### PR TITLE
Fix mounting path when calling docker

### DIFF
--- a/web/web.mk
+++ b/web/web.mk
@@ -1,9 +1,9 @@
 WEB_DOCKER_IMAGE ?= koheron-web:node20
-
+CURRENT_DIR := $(shell pwd -P)
 WEB_DOCKER_RUN := docker run --rm -t \
                   -u $$(id -u):$$(id -g) \
-                  -v $(PWD):$(PWD) \
-                  -w $(PWD) \
+                  -v $(CURRENT_DIR):$(CURRENT_DIR) \
+                  -w $(CURRENT_DIR) \
                   $(WEB_DOCKER_IMAGE)
 
 # Typescript compiler


### PR DESCRIPTION
Fix mounting path when calling docker, when the path you are running from is a symbolic link to a different location