### PR TITLE
Migrate from xsct to xsdb due to xsct deprecation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,14 @@ VIVADO_VERSION := 2025.1
 VIVADO_PATH := /tools/Xilinx/$(VIVADO_VERSION)/Vivado
 VITIS_PATH := /tools/Xilinx/$(VIVADO_VERSION)/Vitis
 VENV := .venv
-HSI := source $(VIVADO_PATH)/settings64.sh && xsct
+VIVADO_MAJOR_VER = $(shell echo $(VIVADO_VERSION) | cut -d. -f1)
+ifeq ($(shell test $(VIVADO_MAJOR_VER) -ge 2024 && echo "true"),true)
+    # Vitis 2024+ - Use xsdb (XSCT deprecated)
+    HSI := source $(VIVADO_PATH)/settings64.sh && xsdb 
+else
+    # Legacy versions (2023.2 and earlier) - Use classic xsct
+    HSI := source $(VIVADO_PATH)/settings64.sh && xsct
+endif
 BOOTGEN := source $(VIVADO_PATH)/settings64.sh && bootgen
 GCC_VERSION := 13
 


### PR DESCRIPTION
XSCT is not present in my 2025.2 installation. The xsct command has been deprecated in Vitis 2024+. This change updates the HSI (Hardware Software Interface) tool invocation to use xsdb for Vitis 2024 and later versions, while maintaining backward compatibility with xsct for older versions.

Proper implementation should use the Vitis Python interface instead of the Tcl-based tools (xsct/xsdb). The Vitis Python interface provides a more modern and maintainable approach for embedded design workflows.

Reference: Vitis Unified Software Platform documentation https://docs.amd.com/r/en-US/ug1165-zynq-embedded-design-tutorial/Vitis-Unified-Software-Platform

Until the proper Vitis Python interface is implemented, xsdb remains capable of running the bitstream.tcl scripts for FPGA programming and hardware management tasks.
https://docs.amd.com/r/en-US/ug1400-vitis-embedded/XSCT-to-Python-API-Migration