### PR TITLE
Update Vivado scripts

### DIFF
--- a/fpga/lib/ctl_sts.tcl
+++ b/fpga/lib/ctl_sts.tcl
@@ -1,4 +1,5 @@
 proc add_ctl_sts {{mclk "None"}  {mrstn "None"}} {
+  global isZynqMP
   if {[info exists config::register_count_control] && $config::register_count_control > 0} {
     add_config_register ctl control $mclk $mrstn config::register_control $config::register_count_control
   }
@@ -6,6 +7,11 @@ proc add_ctl_sts {{mclk "None"}  {mrstn "None"}} {
   if {[info exists config::register_count_status] && $config::register_count_status > 0} {
     add_status_register sts status $mclk $mrstn config::register_status $config::register_count_status
   }
+  #if {$isZynqMP == 0} {
+  #  add_status_register sts status $mclk $mrstn config::sts_register $config::status_size
+  #} else {
+  #  add_status_register sts status $mclk $mrstn config::sts_register $config::status_size 0 0 
+  #}
 
   if {[info exists config::register_count_ps_control] && $config::register_count_ps_control > 0} {
     add_config_register ps_ctl ps_control "None" "None" config::register_ps_control $config::register_count_ps_control
@@ -63,7 +69,14 @@ proc add_config_register {module_name memory_name mclk mrstn reg_names {num_port
   }
 
   assign_bd_address [get_bd_addr_segs {axi_${module_name}_register/s_axi/reg0 }]
-  set memory_segment [get_bd_addr_segs /${::ps_name}/Data/SEG_axi_${module_name}_register_reg0]
+  global isXDma
+  set memory_segment 0
+  
+  if {$isXDma == 1} {
+    set memory_segment [get_bd_addr_segs /${::ps_name}/M_AXI_LITE/SEG_axi_${module_name}_register_reg0]
+  } else {
+    set memory_segment [get_bd_addr_segs /${::ps_name}/Data/SEG_axi_${module_name}_register_reg0]
+  }
   set_property range  [get_memory_range $memory_name]  $memory_segment
   set_property offset [get_memory_offset $memory_name] $memory_segment
 
@@ -86,6 +99,7 @@ proc add_status_register {module_name memory_name mclk mrstn reg_names {num_port
   for {set i 0} {$i < $num_ports} {incr i} {
     create_bd_pin -dir I -from 31 -to 0 $register($i)
   }
+
 
   # Add a new Master Interface to AXI Interconnect
   set idx [add_master_interface $intercon_idx]
@@ -124,7 +138,11 @@ proc add_status_register {module_name memory_name mclk mrstn reg_names {num_port
   }
 
   assign_bd_address [get_bd_addr_segs {axi_${module_name}_register_0/s_axi/reg0 }]
-  set memory_segment [get_bd_addr_segs /${::ps_name}/Data/SEG_axi_${module_name}_register_0_reg0]
+  if {${::isXDma} == 1} {
+    set memory_segment [get_bd_addr_segs /${::ps_name}/M_AXI_LITE/SEG_axi_${module_name}_register_0_reg0]
+  } else {
+    set memory_segment [get_bd_addr_segs /${::ps_name}/Data/SEG_axi_${module_name}_register_0_reg0]
+  }
   set_property range  [get_memory_range $memory_name]  $memory_segment
   set_property offset [get_memory_offset $memory_name] $memory_segment
 

--- a/fpga/lib/ctl_sts.tcl
+++ b/fpga/lib/ctl_sts.tcl
@@ -1,5 +1,4 @@
 proc add_ctl_sts {{mclk "None"}  {mrstn "None"}} {
-  global isZynqMP
   if {[info exists config::register_count_control] && $config::register_count_control > 0} {
     add_config_register ctl control $mclk $mrstn config::register_control $config::register_count_control
   }
@@ -7,11 +6,6 @@ proc add_ctl_sts {{mclk "None"}  {mrstn "None"}} {
   if {[info exists config::register_count_status] && $config::register_count_status > 0} {
     add_status_register sts status $mclk $mrstn config::register_status $config::register_count_status
   }
-  #if {$isZynqMP == 0} {
-  #  add_status_register sts status $mclk $mrstn config::sts_register $config::status_size
-  #} else {
-  #  add_status_register sts status $mclk $mrstn config::sts_register $config::status_size 0 0 
-  #}
 
   if {[info exists config::register_count_ps_control] && $config::register_count_ps_control > 0} {
     add_config_register ps_ctl ps_control "None" "None" config::register_ps_control $config::register_count_ps_control
@@ -69,10 +63,9 @@ proc add_config_register {module_name memory_name mclk mrstn reg_names {num_port
   }
 
   assign_bd_address [get_bd_addr_segs {axi_${module_name}_register/s_axi/reg0 }]
-  global isXDma
   set memory_segment 0
   
-  if {$isXDma == 1} {
+  if {${::dclass} == "xdma"} {
     set memory_segment [get_bd_addr_segs /${::ps_name}/M_AXI_LITE/SEG_axi_${module_name}_register_reg0]
   } else {
     set memory_segment [get_bd_addr_segs /${::ps_name}/Data/SEG_axi_${module_name}_register_reg0]
@@ -138,7 +131,7 @@ proc add_status_register {module_name memory_name mclk mrstn reg_names {num_port
   }
 
   assign_bd_address [get_bd_addr_segs {axi_${module_name}_register_0/s_axi/reg0 }]
-  if {${::isXDma} == 1} {
+  if {${::dclass} == "xdma"} {
     set memory_segment [get_bd_addr_segs /${::ps_name}/M_AXI_LITE/SEG_axi_${module_name}_register_0_reg0]
   } else {
     set memory_segment [get_bd_addr_segs /${::ps_name}/Data/SEG_axi_${module_name}_register_0_reg0]

--- a/fpga/lib/starting_point.tcl
+++ b/fpga/lib/starting_point.tcl
@@ -1,6 +1,5 @@
 set ps_name ps_0
-variable isZynqMP 0
-variable isXDma 0
+variable dclass "zynq"
 
 # Find the number of interconnects
 set i 0

--- a/fpga/lib/starting_point.tcl
+++ b/fpga/lib/starting_point.tcl
@@ -1,4 +1,6 @@
 set ps_name ps_0
+variable isZynqMP 0
+variable isXDma 0
 
 # Find the number of interconnects
 set i 0

--- a/fpga/lib/starting_point_xdma.tcl
+++ b/fpga/lib/starting_point_xdma.tcl
@@ -1,0 +1,83 @@
+set ps_name xdma_0
+
+# Find the number of interconnects
+variable isZynqMP 0
+variable isXDma 1
+set i 0
+while {[info exists config::fclk$i] == 1} {
+  set interconnect_${i}_name axi_mem_intercon_$i
+  set ps_clk$i $ps_name/axi_aclk
+  incr i
+}
+set n_interconnects $i
+
+create_bd_intf_port -mode Master -vlnv xilinx.com:interface:pcie_7x_mgt_rtl:1.0 pcie_7x_mgt 
+create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 PCIe_CLK 
+create_bd_port -dir I -type rst PCIe_RESETN
+
+# Create processing_system7
+cell xilinx.com:ip:util_ds_buf:2.1 util_ds_buf_0 {
+   C_BUF_TYPE IBUFDSGTE
+} {
+  CLK_IN_D PCIe_CLK
+}
+cell xilinx.com:ip:xdma:4.1 $ps_name {
+   PF0_DEVICE_ID_mqdma {9024} 
+   PF2_DEVICE_ID_mqdma {9024} 
+   PF3_DEVICE_ID_mqdma {9024} 
+   axi_data_width {128_bit} 
+   axilite_master_en {true} 
+   axilite_master_size {2} 
+   axilite_master_scale {Gigabytes} 
+   xdma_rnum_chnl {2} 
+   xdma_wnum_chnl {2} 
+   dsc_bypass_rd  {0011}
+   dsc_bypass_wr {0011}
+   axist_bypass_en {false} 
+   axisten_freq {125} 
+   en_transceiver_status_ports {false} 
+   pcie_extended_tag {false} 
+   cfg_mgmt_if false
+   pf0_device_id {7024} 
+   pf0_msi_enabled {false} 
+   xdma_axi_intf_mm {AXI_Stream}
+   pf0_msix_cap_pba_bir {BAR_1} 
+   pf0_msix_cap_table_bir {BAR_1} 
+   pl_link_cap_max_link_speed {5.0_GT/s} 
+   pl_link_cap_max_link_width {X4} 
+   plltype {QPLL1} 
+} {
+  usr_irq_req [get_constant_pin 0 1]
+  sys_rst_n PCIe_RESETN
+  sys_clk util_ds_buf_0/IBUF_OUT
+
+  pcie_mgt pcie_7x_mgt
+}
+
+for {set i 0} {$i < $n_interconnects} {incr i} {
+  # Add processor system reset
+  set rst${i}_name proc_sys_reset_$i
+
+  cell xilinx.com:ip:proc_sys_reset:5.0 [set rst${i}_name] {} {
+    slowest_sync_clk $ps_name/axi_aclk
+    ext_reset_in $ps_name/axi_aresetn
+  }
+  # Add AXI interconnect
+  cell xilinx.com:ip:axi_interconnect:2.1 [set interconnect_${i}_name] {
+    NUM_MI 1
+  } {
+    ARESETN [set rst${i}_name]/interconnect_aresetn
+    S00_ARESETN [set rst${i}_name]/peripheral_aresetn
+    ACLK [set ps_clk$i]
+    S00_ACLK [set ps_clk$i]
+  }
+  connect_bd_intf_net -boundary_type upper [get_bd_intf_pins [set interconnect_${i}_name]/S00_AXI] [get_bd_intf_pins $ps_name/M_AXI_LITE]
+    if {$i == 1} {
+      set bus_id 0
+      set bus_type LPD
+    }
+}
+
+
+source $board_preset
+

--- a/fpga/lib/starting_point_xdma.tcl
+++ b/fpga/lib/starting_point_xdma.tcl
@@ -1,8 +1,7 @@
 set ps_name xdma_0
+variable dclass "xdma"
 
 # Find the number of interconnects
-variable isZynqMP 0
-variable isXDma 1
 set i 0
 while {[info exists config::fclk$i] == 1} {
   set interconnect_${i}_name axi_mem_intercon_$i

--- a/fpga/lib/starting_point_zynqmp.tcl
+++ b/fpga/lib/starting_point_zynqmp.tcl
@@ -1,8 +1,7 @@
 set ps_name ps_0
+variable dclass "zynqmp"
 
 # Find the number of interconnects
-variable isZynqMP 1
-variable isXDma 0
 set i 0
 while {[info exists config::fclk$i] == 1} {
   set interconnect_${i}_name axi_mem_intercon_$i

--- a/fpga/lib/starting_point_zynqmp.tcl
+++ b/fpga/lib/starting_point_zynqmp.tcl
@@ -1,0 +1,76 @@
+set ps_name ps_0
+
+# Find the number of interconnects
+variable isZynqMP 1
+variable isXDma 0
+set i 0
+while {[info exists config::fclk$i] == 1} {
+  set interconnect_${i}_name axi_mem_intercon_$i
+  set ps_clk$i $ps_name/pl_clk$i
+  incr i
+}
+set n_interconnects $i
+
+# Create processing_system7
+cell xilinx.com:ip:zynq_ultra_ps_e:3.3 $ps_name {
+  PSU__USE__M_AXI_GP2 0
+  PSU__FPGA_PL1_ENABLE 1
+} {}
+
+source $board_preset
+set bus_type fpd
+set bus_id 0
+for {set i 0} {$i < $n_interconnects} {incr i} {
+    set_property -dict [list CONFIG.PSU__USE__M_AXI_GP${i} 1] [get_bd_cells $ps_name]
+    set_property -dict [list CONFIG.PSU__FPGA_PL${i}_ENABLE {1} \
+         CONFIG.PSU__CRL_APB__PL${i}_REF_CTRL__FREQMHZ \
+         [expr [set config::fclk$i] / 1000000]] [get_bd_cells $ps_name]
+    connect_pins $ps_name/maxihpm${bus_id}_${bus_type}_aclk [set ps_clk$i]
+    incr bus_id
+    if {$i == 1} {
+      set bus_id 0
+      set bus_type lpd
+    }
+
+}
+
+set bus_type FPD
+set bus_id 0
+for {set i 0} {$i < $n_interconnects} {incr i} {
+  # Add processor system reset
+  set rst${i}_name proc_sys_reset_$i
+
+  cell xilinx.com:ip:proc_sys_reset:5.0 [set rst${i}_name] {} {
+    slowest_sync_clk [set ps_clk$i]
+    ext_reset_in $ps_name/pl_resetn0
+  }
+  # Add AXI interconnect
+  cell xilinx.com:ip:axi_interconnect:2.1 [set interconnect_${i}_name] {
+    NUM_MI 1
+  } {
+    ARESETN [set rst${i}_name]/interconnect_aresetn
+    S00_ARESETN [set rst${i}_name]/peripheral_aresetn
+    ACLK [set ps_clk$i]
+    S00_ACLK [set ps_clk$i]
+  }
+  connect_bd_intf_net -boundary_type upper [get_bd_intf_pins [set interconnect_${i}_name]/S00_AXI] [get_bd_intf_pins $ps_name/M_AXI_HPM${bus_id}_${bus_type}]
+    if {$i == 1} {
+      set bus_id 0
+      set bus_type LPD
+    }
+}
+#
+#cell xilinx.com:ip:system_management_wiz:1.3 system_management_wiz {
+#    CHANNEL_ENABLE_VP_VN {false} 
+#    TEMPERATURE_ALARM_OT_TRIGGER {85} 
+#} {
+#  s_axi_aclk ${ps_name}/pl_clk0
+#  S_AXI_LITE axi_mem_intercon_0/M[add_master_interface]_AXI
+#  s_axi_aresetn proc_sys_reset_0/peripheral_aresetn
+#}
+#assign_bd_address -offset [get_memory_offset system_management_wiz] -range [get_memory_range system_management_wiz] \
+#            -target_address_space [get_bd_addr_spaces ps_0/Data] \
+#            [get_bd_addr_segs adc_311x_0/S00_AXI/Reg] 
+#
+#
+#

--- a/fpga/lib/utilities.tcl
+++ b/fpga/lib/utilities.tcl
@@ -25,23 +25,24 @@ proc _cell_exists {name} { expr {[llength [_bd_cells $name]]} }
 # Get a configuration pin
 # name : name of the register defined in the instrument YAML
 proc ctl_pin {pin_name} {
-  return ctl/$pin_name
+  ## extra "/" needed to allow functions to be called from hierchies 
+  return /ctl/$pin_name
 }
 
 # Get a PS configuration pin
 # name : name of the register defined in the instrument YAML
 proc ps_ctl_pin {pin_name} {
-  return ps_ctl/$pin_name
+  return /ps_ctl/$pin_name
 }
 
 # Get a status pin
 proc sts_pin {pin_name} {
-  return sts/$pin_name
+  return /sts/$pin_name
 }
 
 # Get a PS status pin
 proc ps_sts_pin {pin_name} {
-  return ps_sts/$pin_name
+  return /ps_sts/$pin_name
 }
 
 # Get a parameter defined in main.yml
@@ -130,7 +131,7 @@ foreach op {GE GT LE LT EQ NE} {
 
 proc get_slice_pin {pin_name from to {cell_name ""}} {
   if {$cell_name eq ""} {
-    set cell_name slice_${from}_${to}_[underscore $pin_name]
+    set cell_name slice_${from}_${to}_c[underscore $pin_name]
   }
   if {![_cell_exists $cell_name]} {
     cell xilinx.com:ip:xlslice:1.0 $cell_name {

--- a/fpga/vivado/core.tcl
+++ b/fpga/vivado/core.tcl
@@ -19,6 +19,7 @@ set rtl [concat \
   [glob -nocomplain $core_path/*.sv] \
   [glob -nocomplain $core_path/*.vh] \
   [glob -nocomplain $core_path/*.vhd] \
+  [glob -nocomplain $core_path/*.xci] \
   [glob -nocomplain $core_path/*.vhdl]]
 set cfg [glob -nocomplain $core_path/core_config.tcl]
 set inputs [concat $rtl $cfg]
@@ -59,7 +60,14 @@ if {[file exists $proj_root.xpr]} {
 create_project -part $part $project_name $output_path -force
 
 # Add sources
-foreach f $rtl { add_files -norecurse $f }
+if {[file exists $core_path/load_files.tcl]} {
+    source $sdk_path/fpga/lib/utilities.tcl
+    source $output_path/../fpga/config.tcl
+    source $core_path/load_files.tcl
+    load_files $core_path $output_path $project_name
+} else {
+    foreach f $rtl { add_files -norecurse $f }
+}
 
 # Remove testbenches (fix: use $testbench_files and -nocomplain)
 set testbench_files [glob -nocomplain $core_path/*_tb.v $core_path/*_tb.vh $core_path/*_tb.sv $core_path/*_tb.vhd $core_path/*_tb.vhdl]

--- a/fpga/vivado/project.tcl
+++ b/fpga/vivado/project.tcl
@@ -1,14 +1,15 @@
 source [file join [file dirname [info script]] "block_design.tcl"]
+set_property target_language VHDL [current_project]
 
 set_property synth_checkpoint_mode None [get_files $bd_path/system.bd]
 
 generate_target all [get_files $bd_path/system.bd]
 make_wrapper -files [get_files $bd_path/system.bd] -top
 
-add_files -norecurse $bd_path/hdl/system_wrapper.v
+add_files -norecurse $bd_path/hdl/system_wrapper.vhd
 
 # Add verilog source files
-set files [glob -nocomplain $project_path/*.v $project_path/*.sv]
+set files [glob -nocomplain $project_path/*.v $project_path/*.vhd $project_path/*.sv ]
 if {[llength $files] > 0} {
   add_files -norecurse $files
 }

--- a/fpga/vivado/project.tcl
+++ b/fpga/vivado/project.tcl
@@ -1,12 +1,11 @@
 source [file join [file dirname [info script]] "block_design.tcl"]
-set_property target_language VHDL [current_project]
 
 set_property synth_checkpoint_mode None [get_files $bd_path/system.bd]
 
 generate_target all [get_files $bd_path/system.bd]
 make_wrapper -files [get_files $bd_path/system.bd] -top
 
-add_files -norecurse $bd_path/hdl/system_wrapper.vhd
+add_files -norecurse $bd_path/hdl/system_wrapper.v
 
 # Add verilog source files
 set files [glob -nocomplain $project_path/*.v $project_path/*.vhd $project_path/*.sv ]

--- a/os/rootfs.mk
+++ b/os/rootfs.mk
@@ -442,4 +442,4 @@ flash:
 	FLASH_ALLOWED_MODELS="$(FLASH_ALLOWED_MODELS)" \
 	FLASH_DEVICES="$(FLASH_DEVICES)" \
 	FLASH_DEVICE="$(FLASH_DEVICE)" \
-	python3 $(OS_PATH)/scripts/flash_all.py $(TMP_PROJECT_PATH)/$(RELEASE_NAME).zip
+	$(VENV)/bin/python3 $(OS_PATH)/scripts/flash_all.py $(TMP_PROJECT_PATH)/$(RELEASE_NAME).zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ CppHeaderParser==2.7.4
 numpy>=1.26
 scipy>=1.14
 matplotlib
+tqdm
+colorama


### PR DESCRIPTION
- starting_point_xdma.tcl and zynqmp: Add new ZynqMP and XDMA PCIe processing system configuration -- still have to port scripts to prepare bitstream and the serverd (running on amd64) to control xmda device.
- ctl_sts.tcl: Update to support XDMA memory mapping and ZynqMP
- utilities.tcl: Fix pin paths to work from inside hierarchies
- core.tcl: Add .xci file support and load_files.tcl handling
- project.tcl: Set VHDL as target language and update wrapper extension